### PR TITLE
GROUP BY push down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJS = option.o deparse.o influxdb_query.o influxdb_fdw.o query.a
 EXTENSION = influxdb_fdw
 DATA = influxdb_fdw--1.0.sql
 
-REGRESS = influxdb_fdw
+REGRESS =  aggregate influxdb_fdw
 
 UNAME = uname
 OS := $(shell $(UNAME))

--- a/deparse.c
+++ b/deparse.c
@@ -80,6 +80,7 @@ typedef struct deparse_expr_cxt
 								 * a base relation. */
 	StringInfo	buf;			/* output buffer to append to */
 	List	  **params_list;	/* exprs that will become remote Params */
+	List	   *skip_attrs;		/* attr not added to remote target list */
 } deparse_expr_cxt;
 
 /*
@@ -125,10 +126,8 @@ static void deparseFromExpr(List *quals, deparse_expr_cxt *context);
 static void deparseAggref(Aggref *node, deparse_expr_cxt *context);
 static void appendConditions(List *exprs, deparse_expr_cxt *context);
 static void appendGroupByClause(List *tlist, deparse_expr_cxt *context);
-static void appendAggOrderBy(List *orderList, List *targetList,
-				 deparse_expr_cxt *context);
+
 static void appendOrderByClause(List *pathkeys, deparse_expr_cxt *context);
-static void appendFunctionName(Oid funcid, deparse_expr_cxt *context);
 static Node *deparseSortGroupClause(Index ref, List *tlist,
 					   deparse_expr_cxt *context);
 static void deparseExplicitTargetList(List *tlist, List **retrieved_attrs,
@@ -170,7 +169,6 @@ influxdb_deparse_relation(StringInfo buf, Relation rel)
 	if (relname == NULL)
 		relname = RelationGetRelationName(rel);
 
-
 	appendStringInfo(buf, "%s", influxdb_quote_identifier(relname, QUOTE));
 }
 
@@ -192,9 +190,6 @@ influxdb_quote_identifier(const char *s, char q)
 	*r++ = '\0';
 	return result;
 }
-
-
-
 
 /*
  * Returns true if given expr is safe to evaluate on the foreign server.
@@ -386,7 +381,7 @@ foreign_expr_walker(Node *node,
 
 				if (!is_valid_type(p->paramtype))
 					return false;
-					
+
 				/*
 				 * Collation rule is same as for Consts and non-foreign Vars.
 				 */
@@ -404,7 +399,6 @@ foreign_expr_walker(Node *node,
 
 				FuncExpr   *fe = (FuncExpr *) node;
 				char	   *opername = NULL;
-				Oid			schema;
 
 				/* get function name and schema */
 				tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(fe->funcid));
@@ -413,15 +407,11 @@ foreign_expr_walker(Node *node,
 					elog(ERROR, "cache lookup failed for function %u", fe->funcid);
 				}
 				opername = pstrdup(((Form_pg_proc) GETSTRUCT(tuple))->proname.data);
-				schema = ((Form_pg_proc) GETSTRUCT(tuple))->pronamespace;
 				ReleaseSysCache(tuple);
 
-				/* ignore functions in other than the pg_catalog schema */
-				if (schema != PG_CATALOG_NAMESPACE)
-					return false;
-
-				/* Only now() is pushed down to InfluxDB */
-				if (strcmp(opername, "now") != 0)
+				/* pushed down to InfluxDB */
+				if (strcmp(opername, "now") != 0 &&
+					strcmp(opername, "by_interval") != 0)
 				{
 					return false;
 				}
@@ -459,7 +449,6 @@ foreign_expr_walker(Node *node,
 					state = FDW_COLLATE_NONE;
 				else
 					state = FDW_COLLATE_UNSAFE;
-
 			}
 			break;
 		case T_OpExpr:
@@ -630,7 +619,6 @@ foreign_expr_walker(Node *node,
 				ListCell   *lc;
 				FuncExpr   *func = (FuncExpr *) node;
 				char	   *opername = NULL;
-				Oid			schema;
 
 				/* get function name and schema */
 				tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(agg->aggfnoid));
@@ -639,18 +627,14 @@ foreign_expr_walker(Node *node,
 					elog(ERROR, "cache lookup failed for function %u", func->funcid);
 				}
 				opername = pstrdup(((Form_pg_proc) GETSTRUCT(tuple))->proname.data);
-				schema = ((Form_pg_proc) GETSTRUCT(tuple))->pronamespace;
 				ReleaseSysCache(tuple);
 
-				/* ignore functions in other than the pg_catalog schema */
-				if (schema != PG_CATALOG_NAMESPACE)
-					return false;
-
-				/* these function can be passed to SQLite */
+				/* these function can be passed to InfluxDB */
 				if (!(strcmp(opername, "sum") == 0
 					  || strcmp(opername, "max") == 0
 					  || strcmp(opername, "min") == 0
-					  || strcmp(opername, "count") == 0))
+					  || strcmp(opername, "count") == 0
+					  || strcmp(opername, "last") == 0))
 				{
 					return false;
 				}
@@ -827,7 +811,6 @@ influxdb_build_tlist_to_deparse(RelOptInfo *foreignrel)
 	return tlist;
 }
 
-
 /*
  * Deparse SELECT statement for given relation into buf.
  *
@@ -853,7 +836,7 @@ void
 influxdbDeparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel,
 								List *tlist, List *remote_conds, List *pathkeys,
 								bool is_subquery, List **retrieved_attrs,
-								List **params_list)
+								List **params_list, List **skip_attrs)
 {
 	deparse_expr_cxt context;
 	InfluxDBFdwRelationInfo *fpinfo = (InfluxDBFdwRelationInfo *) rel->fdw_private;
@@ -871,11 +854,12 @@ influxdbDeparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *r
 	context.buf = buf;
 	context.root = root;
 	context.foreignrel = rel;
-	context.scanrel = (rel->reloptkind == RELOPT_UPPER_REL) ?
-		fpinfo->outerrel : rel;
+	context.scanrel = (rel->reloptkind == RELOPT_UPPER_REL) ? fpinfo->outerrel : rel;
 	context.params_list = params_list;
+	context.skip_attrs = NIL;
 	/* Construct SELECT clause */
 	influxdb_deparse_select(tlist, retrieved_attrs, &context);
+	*skip_attrs = context.skip_attrs;
 
 	/*
 	 * For upper relations, the WHERE clause is built from the remote
@@ -911,10 +895,7 @@ influxdbDeparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *r
 	/* Add ORDER BY clause if we found any useful pathkeys */
 	if (pathkeys)
 		appendOrderByClause(pathkeys, &context);
-
 }
-
-
 
 /*
  * Deparese SELECT statment
@@ -993,7 +974,6 @@ deparseFromExpr(List *quals, deparse_expr_cxt *context)
 	}
 }
 
-
 /*
  * Deparse conditions from the provided list and append them to buf.
  *
@@ -1033,7 +1013,6 @@ appendConditions(List *exprs, deparse_expr_cxt *context)
 	influxdb_reset_transmission_modes(nestlevel);
 }
 
-
 /*
  * Deparse given targetlist and append it to context->buf.
  *
@@ -1049,17 +1028,28 @@ deparseExplicitTargetList(List *tlist, List **retrieved_attrs,
 	ListCell   *lc;
 	StringInfo	buf = context->buf;
 	int			i = 0;
+	bool		first = true;
 
 	*retrieved_attrs = NIL;
 
 	foreach(lc, tlist)
 	{
 		TargetEntry *tle = lfirst_node(TargetEntry, lc);
+		bool		skip;
 
-		if (i > 0)
-			appendStringInfoString(buf, ", ");
-		deparseExpr((Expr *) tle->expr, context);
-
+		if (IsA((Expr *) tle->expr, Aggref))
+		{
+			skip = false;
+			if (!first)
+				appendStringInfoString(buf, ", ");
+			first = false;
+			deparseExpr((Expr *) tle->expr, context);
+		}
+		else
+		{
+			skip = true;
+		}
+		context->skip_attrs = lappend_int(context->skip_attrs, skip);
 		*retrieved_attrs = lappend_int(*retrieved_attrs, i + 1);
 		i++;
 	}
@@ -1067,7 +1057,6 @@ deparseExplicitTargetList(List *tlist, List **retrieved_attrs,
 	if (i == 0)
 		appendStringInfoString(buf, "*");
 }
-
 
 /*
  * Construct FROM clause for given relation
@@ -1101,7 +1090,6 @@ deparseFromExprForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
 		heap_close(rel, NoLock);
 	}
 }
-
 
 void
 influxdb_deparse_analyze(StringInfo sql, char *dbname, char *relname)
@@ -1168,7 +1156,6 @@ influxdb_deparse_target_list(StringInfo buf,
 		appendStringInfoString(buf, "*");
 }
 
-
 /*
  * Deparse WHERE clauses in given list of RestrictInfos and append them to buf.
  *
@@ -1221,7 +1208,6 @@ influxdb_append_where_clause(StringInfo buf,
 	}
 }
 
-
 static char *
 influxdb_get_column_ref(StringInfo buf, int varno, int varattno, Oid vartype,
 						PlannerInfo *root)
@@ -1260,7 +1246,8 @@ influxdb_get_column_ref(StringInfo buf, int varno, int varattno, Oid vartype,
 	if (colname == NULL)
 		colname = get_attname(rte->relid, varattno
 #if (PG_VERSION_NUM >= 110000)
-							  ,false
+							  ,
+							  false
 #endif
 			);
 	return colname;
@@ -1308,7 +1295,8 @@ influxdb_deparse_column_ref(StringInfo buf, int varno, int varattno, Oid vartype
 	if (colname == NULL)
 		colname = get_attname(rte->relid, varattno
 #if (PG_VERSION_NUM >= 110000)
-							  ,false
+							  ,
+							  false
 #endif
 			);
 	if (convert && vartype == BOOLOID)
@@ -1322,44 +1310,6 @@ influxdb_deparse_column_ref(StringInfo buf, int varno, int varattno, Oid vartype
 		else
 			appendStringInfoString(buf, influxdb_quote_identifier(colname, QUOTE));
 	}
-
-}
-
-
-static void
-influxdb_deparse_string(StringInfo buf, const char *val, bool isstr)
-{
-	const char *valptr;
-	int			i = -1;
-
-	for (valptr = val; *valptr; valptr++)
-	{
-		char		ch = *valptr;
-
-		i++;
-
-		if (i == 0 && isstr)
-			appendStringInfoChar(buf, '\'');
-
-		/*
-		 * Remove '{', '}' and \" character from the string. Because this
-		 * syntax is not recognize by the remote InfluxDB server.
-		 */
-		if ((ch == '{' && i == 0) || (ch == '}' && (i == (strlen(val) - 1))) || ch == '\"')
-			continue;
-
-		if (ch == ',' && isstr)
-		{
-			appendStringInfoChar(buf, '\'');
-			appendStringInfoChar(buf, ch);
-			appendStringInfoChar(buf, ' ');
-			appendStringInfoChar(buf, '\'');
-			continue;
-		}
-		appendStringInfoChar(buf, ch);
-	}
-	if (isstr)
-		appendStringInfoChar(buf, '\'');
 }
 
 /*
@@ -1440,9 +1390,6 @@ deparseExpr(Expr *node, deparse_expr_cxt *context)
 	}
 }
 
-
-
-
 /*
  * Deparse given Var node into context->buf.
  *
@@ -1466,7 +1413,6 @@ influxdb_deparse_var(Var *node, deparse_expr_cxt *context)
 	{
 		/* Var belongs to foreign table */
 		influxdb_deparse_column_ref(buf, node->varno, node->varattno, node->vartype, context->root, true);
-
 	}
 	else
 	{
@@ -1599,26 +1545,12 @@ influxdb_deparse_const(Const *node, deparse_expr_cxt *context, int showtype)
 				fsec_t		fsec;
 
 				interval2tm(*interval, &tm, &fsec);
-				if (tm.tm_mday)
-				{
-					appendStringInfo(buf, "%dd", tm.tm_mday);
-				}
-				if (tm.tm_hour)
-				{
-					appendStringInfo(buf, "%dh", tm.tm_hour);
-				}
-				if (tm.tm_min)
-				{
-					appendStringInfo(buf, "%dm", tm.tm_min);
-				}
-				if (tm.tm_sec)
-				{
-					appendStringInfo(buf, "%ds", tm.tm_sec);
-				}
-				if (fsec)
-				{
-					appendStringInfo(buf, "%du", fsec);
-				}
+
+				appendStringInfo(buf, "%dd%dh%dm%ds%du", tm.tm_mday, tm.tm_hour,
+								 tm.tm_min, tm.tm_sec, fsec
+					);
+
+
 				break;
 			}
 		default:
@@ -1701,6 +1633,32 @@ influxdb_deparse_func_expr(FuncExpr *node, deparse_expr_cxt *context)
 		elog(ERROR, "cache lookup failed for function %u", node->funcid);
 	procform = (Form_pg_proc) GETSTRUCT(proctup);
 
+	/* convert by_interval(time, interval '2h') to time(2h) */
+	if (strcmp(NameStr(procform->proname), "by_interval") == 0)
+	{
+		int			idx = 0;
+
+		appendStringInfo(buf, "time(");
+
+		first = true;
+		foreach(arg, node->args)
+		{
+			if (idx == 0)
+			{
+				idx++;
+				continue;
+			}
+			if (idx >= 2)
+				appendStringInfoString(buf, ", ");
+
+			deparseExpr((Expr *) lfirst(arg), context);
+			idx++;
+		}
+		appendStringInfoChar(buf, ')');
+		ReleaseSysCache(proctup);
+		return;
+	}
+
 	/* Translate PostgreSQL function into influxdb function */
 	proname = influxdb_replace_function(NameStr(procform->proname));
 
@@ -1713,6 +1671,7 @@ influxdb_deparse_func_expr(FuncExpr *node, deparse_expr_cxt *context)
 	{
 		if (!first)
 			appendStringInfoString(buf, ", ");
+
 		deparseExpr((Expr *) lfirst(arg), context);
 		first = false;
 	}
@@ -2091,6 +2050,7 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 {
 	StringInfo	buf = context->buf;
 	bool		use_variadic;
+	char	   *func_name;
 
 	/* Only basic, non-split aggregation accepted. */
 	Assert(node->aggsplit == AGGSPLIT_SIMPLE);
@@ -2099,77 +2059,51 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 	use_variadic = node->aggvariadic;
 
 	/* Find aggregate name from aggfnoid which is a pg_proc entry */
-	appendFunctionName(node->aggfnoid, context);
+	func_name = influxdb_get_function_name(node->aggfnoid);
+
+	if (strcmp(func_name, "last") == 0)
+	{
+		/* Convert last(time, value) to last(value) */
+		Assert(list_length(node->args) == 2);
+		appendStringInfo(buf, "last(");
+		deparseExpr((Expr *) (((TargetEntry *) list_nth(node->args, 1))->expr), context);
+		appendStringInfoChar(buf, ')');
+		return;
+	}
+
+	appendStringInfo(buf, "%s", quote_identifier(func_name));
 	appendStringInfoChar(buf, '(');
 
 	/* Add DISTINCT */
 	appendStringInfo(buf, "%s", (node->aggdistinct != NIL) ? "DISTINCT " : "");
 
-	if (AGGKIND_IS_ORDERED_SET(node->aggkind))
+	/* aggstar can be set only in zero-argument aggregates */
+	if (node->aggstar)
+		appendStringInfoChar(buf, '*');
+	else
 	{
-		/* Add WITHIN GROUP (ORDER BY ..) */
 		ListCell   *arg;
 		bool		first = true;
 
-		Assert(!node->aggvariadic);
-		Assert(node->aggorder != NIL);
-
-		foreach(arg, node->aggdirectargs)
+		/* Add all the arguments */
+		foreach(arg, node->args)
 		{
+			TargetEntry *tle = (TargetEntry *) lfirst(arg);
+			Node	   *n = (Node *) tle->expr;
+
+			if (tle->resjunk)
+				continue;
+
 			if (!first)
 				appendStringInfoString(buf, ", ");
 			first = false;
 
-			deparseExpr((Expr *) lfirst(arg), context);
+			/* Add VARIADIC */
+			if (use_variadic && lnext(arg) == NULL)
+				appendStringInfoString(buf, "VARIADIC ");
+
+			deparseExpr((Expr *) n, context);
 		}
-
-		appendStringInfoString(buf, ") WITHIN GROUP (ORDER BY ");
-		appendAggOrderBy(node->aggorder, node->args, context);
-	}
-	else
-	{
-		/* aggstar can be set only in zero-argument aggregates */
-		if (node->aggstar)
-			appendStringInfoChar(buf, '*');
-		else
-		{
-			ListCell   *arg;
-			bool		first = true;
-
-			/* Add all the arguments */
-			foreach(arg, node->args)
-			{
-				TargetEntry *tle = (TargetEntry *) lfirst(arg);
-				Node	   *n = (Node *) tle->expr;
-
-				if (tle->resjunk)
-					continue;
-
-				if (!first)
-					appendStringInfoString(buf, ", ");
-				first = false;
-
-				/* Add VARIADIC */
-				if (use_variadic && lnext(arg) == NULL)
-					appendStringInfoString(buf, "VARIADIC ");
-
-				deparseExpr((Expr *) n, context);
-			}
-		}
-
-		/* Add ORDER BY */
-		if (node->aggorder != NIL)
-		{
-			appendStringInfoString(buf, " ORDER BY ");
-			appendAggOrderBy(node->aggorder, node->args, context);
-		}
-	}
-
-	/* Add FILTER (WHERE ..) */
-	if (node->aggfilter != NULL)
-	{
-		appendStringInfoString(buf, ") FILTER (WHERE ");
-		deparseExpr((Expr *) node->aggfilter, context);
 	}
 
 	appendStringInfoChar(buf, ')');
@@ -2210,61 +2144,6 @@ appendGroupByClause(List *tlist, deparse_expr_cxt *context)
 	}
 }
 
-
-/*
- * Append ORDER BY within aggregate function.
- */
-static void
-appendAggOrderBy(List *orderList, List *targetList, deparse_expr_cxt *context)
-{
-	StringInfo	buf = context->buf;
-	ListCell   *lc;
-	bool		first = true;
-
-	foreach(lc, orderList)
-	{
-		SortGroupClause *srt = (SortGroupClause *) lfirst(lc);
-		Node	   *sortexpr;
-		Oid			sortcoltype;
-		TypeCacheEntry *typentry;
-
-		if (!first)
-			appendStringInfoString(buf, ", ");
-		first = false;
-
-		sortexpr = deparseSortGroupClause(srt->tleSortGroupRef, targetList,
-										  context);
-		sortcoltype = exprType(sortexpr);
-		/* See whether operator is default < or > for datatype */
-		typentry = lookup_type_cache(sortcoltype,
-									 TYPECACHE_LT_OPR | TYPECACHE_GT_OPR);
-		if (srt->sortop == typentry->lt_opr)
-			appendStringInfoString(buf, " ASC");
-		else if (srt->sortop == typentry->gt_opr)
-			appendStringInfoString(buf, " DESC");
-		else
-		{
-			HeapTuple	opertup;
-			Form_pg_operator operform;
-
-			appendStringInfoString(buf, " USING ");
-
-			/* Append operator name. */
-			opertup = SearchSysCache1(OPEROID, ObjectIdGetDatum(srt->sortop));
-			if (!HeapTupleIsValid(opertup))
-				elog(ERROR, "cache lookup failed for operator %u", srt->sortop);
-			operform = (Form_pg_operator) GETSTRUCT(opertup);
-			influxdb_deparse_operator_name(buf, operform);
-			ReleaseSysCache(opertup);
-		}
-
-		if (srt->nulls_first)
-			appendStringInfoString(buf, " NULLS FIRST");
-		else
-			appendStringInfoString(buf, " NULLS LAST");
-	}
-}
-
 /*
  * Find an equivalence class member expression, all of whose Vars, come from
  * the indicated relation.
@@ -2292,7 +2171,6 @@ find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
 	/* We didn't find any suitable equivalence class expression */
 	return NULL;
 }
-
 
 /*
  * Deparse ORDER BY clause according to the given pathkeys for given base
@@ -2338,33 +2216,22 @@ appendOrderByClause(List *pathkeys, deparse_expr_cxt *context)
  * appendFunctionName
  *		Deparses function name from given function oid.
  */
-static void
-appendFunctionName(Oid funcid, deparse_expr_cxt *context)
+char *
+influxdb_get_function_name(Oid funcid)
 {
-	StringInfo	buf = context->buf;
+
 	HeapTuple	proctup;
 	Form_pg_proc procform;
-	const char *proname;
+	char	   *proname;
 
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 	if (!HeapTupleIsValid(proctup))
 		elog(ERROR, "cache lookup failed for function %u", funcid);
 	procform = (Form_pg_proc) GETSTRUCT(proctup);
-
-	/* Print schema name only if it's not pg_catalog */
-	if (procform->pronamespace != PG_CATALOG_NAMESPACE)
-	{
-		const char *schemaname;
-
-		schemaname = get_namespace_name(procform->pronamespace);
-		appendStringInfo(buf, "%s.", quote_identifier(schemaname));
-	}
-
 	/* Always print the function name */
-	proname = NameStr(procform->proname);
-	appendStringInfo(buf, "%s", quote_identifier(proname));
-
+	proname = pstrdup(NameStr(procform->proname));
 	ReleaseSysCache(proctup);
+	return proname;
 }
 
 /*

--- a/expected/aggregate.out
+++ b/expected/aggregate.out
@@ -9,16 +9,6 @@ CREATE SERVER server1 FOREIGN DATA WRAPPER influxdb_fdw OPTIONS
 CREATE USER MAPPING FOR CURRENT_USER SERVER server1 OPTIONS(user 'user', password 'pass');
 -- import time column as timestamp and text type
 IMPORT FOREIGN SCHEMA public FROM SERVER server1 INTO public OPTIONS(import_time_text 'true');
-CREATE FUNCTION influx_time(timestamp with time zone, interval, interval) RETURNS timestamp with time zone AS $$
-BEGIN
-RAISE 'Cannot execute this function in PostgreSQL';
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
-CREATE FUNCTION influx_time(timestamp with time zone, interval) RETURNS timestamp with time zone AS $$
-BEGIN
-RAISE 'Cannot execute this function in PostgreSQL';
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
 --ALTER EXTENSION influxdb_fdw ADD FUNCTION postgres_fdw_abs(int);
 --ALTER SERVER server1 OPTIONS (ADD extensions 'influxdb_fdw');
 SELECT * FROM t4;
@@ -97,31 +87,6 @@ EXPLAIN (verbose)  SELECT tag1,sum("value1"), count(value1), tag2 FROM "t4" grou
    InfluxDB query: SELECT sum("value1"), count("value1") FROM "t4" GROUP BY "tag1", "tag2"
 (3 rows)
 
-CREATE FUNCTION last_value_sfunc(anyelement, timestamp with time zone, anyelement)
-RETURNS anyelement
-IMMUTABLE
-LANGUAGE PLPGSQL
-AS $$
-BEGIN
-  RAISE 'Cannot execute this function in PostgreSQL';
-END;
-$$;
-CREATE FUNCTION last_value_finalfunc_bigint(anyelement)
-RETURNS anyelement
-IMMUTABLE
-LANGUAGE PLPGSQL
-AS $$
-BEGIN
-  RAISE 'Cannot execute this function in PostgreSQL';
-END;
-$$;
-CREATE AGGREGATE last (timestamp with time zone, anyelement)
-(
-    sfunc = last_value_sfunc,
-    --basetype = anyelement,
-    stype = anyelement
-    --finalfunc = last_value_finalfunc_text
-);
 SELECT influx_time(time,interval '5s',interval '0s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
  GROUP BY influx_time(time,interval '5s', interval '0s'), tag1;
       influx_time       | tag1 | last 

--- a/expected/aggregate.out
+++ b/expected/aggregate.out
@@ -1,0 +1,184 @@
+--SET log_min_messages=debug1;
+--SET client_min_messages=debug1;
+SET datestyle=ISO;
+-- timestamp with time zone differs based on this
+SET timezone='UTC';
+CREATE EXTENSION influxdb_fdw;
+CREATE SERVER server1 FOREIGN DATA WRAPPER influxdb_fdw OPTIONS
+(dbname 'mydb', host 'http://localhost', port '8086') ;
+CREATE USER MAPPING FOR CURRENT_USER SERVER server1 OPTIONS(user 'user', password 'pass');
+-- import time column as timestamp and text type
+IMPORT FOREIGN SCHEMA public FROM SERVER server1 INTO public OPTIONS(import_time_text 'true');
+CREATE FUNCTION influx_time(timestamp with time zone, interval, interval) RETURNS timestamp with time zone AS $$
+BEGIN
+RAISE 'Cannot execute this function in PostgreSQL';
+END
+$$ LANGUAGE plpgsql IMMUTABLE;
+CREATE FUNCTION influx_time(timestamp with time zone, interval) RETURNS timestamp with time zone AS $$
+BEGIN
+RAISE 'Cannot execute this function in PostgreSQL';
+END
+$$ LANGUAGE plpgsql IMMUTABLE;
+--ALTER EXTENSION influxdb_fdw ADD FUNCTION postgres_fdw_abs(int);
+--ALTER SERVER server1 OPTIONS (ADD extensions 'influxdb_fdw');
+SELECT * FROM t4;
+          time          |      time_text       | tag1 | tag2 | value1 | value2 
+------------------------+----------------------+------+------+--------+--------
+ 1970-01-01 00:00:00+00 | 1970-01-01T00:00:00Z | a    | x    |      1 |    100
+ 1970-01-01 00:00:01+00 | 1970-01-01T00:00:01Z | a    | y    |      2 |    100
+ 1970-01-01 00:00:02+00 | 1970-01-01T00:00:02Z | a    | x    |      3 |    100
+ 1970-01-01 00:00:03+00 | 1970-01-01T00:00:03Z | b    | y    |     10 |    200
+ 1970-01-01 00:00:04+00 | 1970-01-01T00:00:04Z | b    | z    |     20 |    200
+ 1970-01-01 00:00:05+00 | 1970-01-01T00:00:05Z | b    | z    |     30 |    200
+(6 rows)
+
+EXPLAIN (verbose)  
+SELECT sum("value1"),influx_time(time,interval '1s', interval '0.00001s'),tag1 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '1s', interval '0.00001s'), tag1;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan  (cost=1.00..1.00 rows=1 width=48)
+   Output: (sum(value1)), (influx_time("time", '@ 1 sec'::interval, '@ 0.00001 secs'::interval)), tag1
+   InfluxDB query: SELECT sum("value1") FROM "t4" WHERE ((time >= '1970-01-01 00:00:00')) AND ((time <= '1970-01-01 00:00:05')) GROUP BY (time(0d0h0m1s0u, 0d0h0m0s10u)), "tag1"
+(3 rows)
+
+SELECT sum("value1"),influx_time(time,interval '1s', interval '0.00001s'),tag1 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '1s', interval '0.00001s'), tag1;
+ sum |         influx_time          | tag1 
+-----+------------------------------+------
+   1 | 1969-12-31 23:59:59.00001+00 | a
+   2 | 1970-01-01 00:00:00.00001+00 | a
+   3 | 1970-01-01 00:00:01.00001+00 | a
+     | 1970-01-01 00:00:02.00001+00 | a
+     | 1970-01-01 00:00:03.00001+00 | a
+     | 1970-01-01 00:00:04.00001+00 | a
+     | 1969-12-31 23:59:59.00001+00 | b
+     | 1970-01-01 00:00:00.00001+00 | b
+     | 1970-01-01 00:00:01.00001+00 | b
+  10 | 1970-01-01 00:00:02.00001+00 | b
+  20 | 1970-01-01 00:00:03.00001+00 | b
+  30 | 1970-01-01 00:00:04.00001+00 | b
+(12 rows)
+
+EXPLAIN (verbose) 
+SELECT tag1,sum("value1"),tag2 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+ GROUP BY tag2, tag1;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan  (cost=1.00..1.00 rows=1 width=72)
+   Output: tag1, (sum(value1)), tag2
+   InfluxDB query: SELECT sum("value1") FROM "t4" WHERE ((time >= '1970-01-01 00:00:00')) AND ((time <= '1970-01-01 00:00:05')) GROUP BY "tag2", "tag1"
+(3 rows)
+
+SELECT tag1,sum("value1"),tag2 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+ GROUP BY tag2, tag1;
+ tag1 | sum | tag2 
+------+-----+------
+ a    |   4 | x
+ a    |   2 | y
+ b    |  10 | y
+ b    |  50 | z
+(4 rows)
+
+SELECT tag1,sum("value1"), count(value1), tag2 FROM "t4" group by tag1, tag2;
+ tag1 | sum | count | tag2 
+------+-----+-------+------
+ a    |   4 |     2 | x
+ a    |   2 |     1 | y
+ b    |  10 |     1 | y
+ b    |  50 |     2 | z
+(4 rows)
+
+EXPLAIN (verbose)  SELECT tag1,sum("value1"), count(value1), tag2 FROM "t4" group by tag1, tag2;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Foreign Scan  (cost=1.00..1.00 rows=1 width=80)
+   Output: tag1, (sum(value1)), (count(value1)), tag2
+   InfluxDB query: SELECT sum("value1"), count("value1") FROM "t4" GROUP BY "tag1", "tag2"
+(3 rows)
+
+CREATE FUNCTION last_value_sfunc(anyelement, timestamp with time zone, anyelement)
+RETURNS anyelement
+IMMUTABLE
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE 'Cannot execute this function in PostgreSQL';
+END;
+$$;
+CREATE FUNCTION last_value_finalfunc_bigint(anyelement)
+RETURNS anyelement
+IMMUTABLE
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE 'Cannot execute this function in PostgreSQL';
+END;
+$$;
+CREATE AGGREGATE last (timestamp with time zone, anyelement)
+(
+    sfunc = last_value_sfunc,
+    --basetype = anyelement,
+    stype = anyelement
+    --finalfunc = last_value_finalfunc_text
+);
+SELECT influx_time(time,interval '5s',interval '0s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+ GROUP BY influx_time(time,interval '5s', interval '0s'), tag1;
+      influx_time       | tag1 | last 
+------------------------+------+------
+ 1970-01-01 00:00:00+00 | a    |    3
+ 1970-01-01 00:00:05+00 | a    |     
+ 1970-01-01 00:00:00+00 | b    |   20
+ 1970-01-01 00:00:05+00 | b    |   30
+(4 rows)
+
+EXPLAIN (VERBOSE)
+SELECT influx_time(time,interval '5s',interval '0s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '5s', interval '0s'), tag1;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan  (cost=1.00..1.00 rows=1 width=48)
+   Output: (influx_time("time", '@ 5 secs'::interval, '@ 0'::interval)), tag1, (last("time", value1))
+   InfluxDB query: SELECT last("value1") FROM "t4" WHERE ((time >= '1970-01-01 00:00:00')) AND ((time <= '1970-01-01 00:00:05')) GROUP BY (time(0d0h0m5s0u, 0d0h0m0s0u)), "tag1"
+(3 rows)
+
+-- no offset 
+SELECT influx_time(time,interval '5s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '5s'), tag1;
+      influx_time       | tag1 | last 
+------------------------+------+------
+ 1970-01-01 00:00:00+00 | a    |    3
+ 1970-01-01 00:00:05+00 | a    |     
+ 1970-01-01 00:00:00+00 | b    |   20
+ 1970-01-01 00:00:05+00 | b    |   30
+(4 rows)
+
+EXPLAIN (verbose) 
+SELECT last(time, value1),last(time, value2) FROM t4 GROUP BY tag1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan  (cost=1.00..1.00 rows=1 width=48)
+   Output: (last("time", value1)), (last("time", value2)), tag1
+   InfluxDB query: SELECT last("value1"), last("value2") FROM "t4" GROUP BY "tag1"
+(3 rows)
+
+SELECT last(time, value1),last(time, value2) FROM t4 GROUP BY tag1;
+ last | last 
+------+------
+    3 |  100
+   30 |  200
+(2 rows)
+
+-- InfluxDB does not return error for the following query
+--SELECT sum(value1) FROM t4 GROUP BY value1;
+-- not allowed
+SELECT sum(value1) FROM t4 GROUP BY time;
+ERROR:  influxdb_fdw : time() is a function and expects at least one argument
+--last returns NULL for tag
+--SELECT last(time, value1),last(time, value2),last(time, tag1) FROM t4 GROUP BY tag1;
+DROP FOREIGN TABLE t3;
+DROP FOREIGN TABLE t4;
+DROP FOREIGN TABLE cpu;
+DROP USER MAPPING FOR CURRENT_USER SERVER server1;
+DROP SERVER server1;
+DROP EXTENSION influxdb_fdw ;

--- a/expected/influxdb_fdw.out
+++ b/expected/influxdb_fdw.out
@@ -42,8 +42,9 @@ SELECT value1,time_text,value2 FROM cpu;
 
 DROP FOREIGN TABLE cpu;
 DROP FOREIGN TABLE t3;
+DROP FOREIGN TABLE t4;
 -- test EXECPT
-IMPORT FOREIGN SCHEMA public EXCEPT (cpu,t3) FROM SERVER server1 INTO public;
+IMPORT FOREIGN SCHEMA public EXCEPT (cpu,t3, t4) FROM SERVER server1 INTO public;
 SELECT ftoptions FROM pg_foreign_table;
  ftoptions 
 -----------
@@ -342,68 +343,6 @@ EXPLAIN (verbose)  SELECT * FROM t2 WHERE time = TIMESTAMP '2015-09-18 00:00:00'
    InfluxDB query: SELECT "tag1", "value1" FROM "cpu" WHERE ((time = '2015-08-18 00:00:00'))
 (3 rows)
 
-SELECT * FROM t3;
-          time          | tag1 | value1 | value2 
-------------------------+------+--------+--------
- 1970-01-01 09:00:00+09 | a    |      1 |    100
- 1970-01-01 09:00:01+09 | a    |      2 |    100
- 1970-01-01 09:00:02+09 | a    |      3 |    100
- 1970-01-01 09:00:03+09 | b    |     10 |    200
- 1970-01-01 09:00:04+09 | b    |     20 |    200
-(5 rows)
-
-EXPLAIN (verbose, costs off) SELECT
-sum(value1), max(value1),count(*) FROM t3;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Foreign Scan
-   Output: (sum(value1)), (max(value1)), (count(*))
-   InfluxDB query: SELECT sum("value1"), max("value1"), count(*) FROM "t3"
-(3 rows)
-
-SELECT sum(value1), max(value1),count(*) FROM t3;
- sum | max | count 
------+-----+-------
-  36 |  20 |     5
-(1 row)
-
-EXPLAIN (verbose, costs off) 
-SELECT avg(value1) FROM t3;
-                    QUERY PLAN                     
----------------------------------------------------
- Aggregate
-   Output: avg(value1)
-   ->  Foreign Scan on public.t3
-         Output: "time", tag1, value1, value2
-         InfluxDB query: SELECT "value1" FROM "t3"
-(5 rows)
-
-SELECT avg(value1) FROM t3;
- avg 
------
- 7.2
-(1 row)
-
--- Not pushdown aggregates with GROUP BY because "SELECT sum(value1),tag1" cause error "mixing aggregate and non-aggregate queries is not supported"
-EXPLAIN (verbose, costs off) 
-SELECT sum(value1) FROM t3 GROUP BY "tag1";
-                        QUERY PLAN                         
------------------------------------------------------------
- HashAggregate
-   Output: sum(value1), tag1
-   Group Key: t3.tag1
-   ->  Foreign Scan on public.t3
-         Output: "time", tag1, value1, value2
-         InfluxDB query: SELECT "tag1", "value1" FROM "t3"
-(6 rows)
-
-SELECT sum(value1) FROM t3 GROUP BY "tag1";
- sum 
------
-   6
-  30
-(2 rows)
-
 -- Currently using column_name 'time' does not work 
 -- CREATE FOREIGN TABLE t(tm timestamp OPTIONS (column_name 'time'),tm_with_zone timestamp with time zone OPTIONS (column_name 'time'), tag1 text,value1 integer) SERVER server1  OPTIONS (table 'cpu');
 SELECT * FROM t2 WHERE value1 = ANY (ARRAY(SELECT value1 FROM t1 WHERE value1 < 1000));
@@ -424,8 +363,8 @@ SELECT * FROM t1;
  2015-08-18 09:00:00+09 | tag1_B |    100
 (2 rows)
 
-CREATE FOREIGN TABLE t4(t timestamp OPTIONS (column_name 'time') , tag1 text OPTIONS (column_name 'time'), v1  integer OPTIONS (column_name 'value1')) SERVER server1  OPTIONS (table 'cpu');
-SELECT * FROM t4;
+CREATE FOREIGN TABLE t5(t timestamp OPTIONS (column_name 'time') , tag1 text OPTIONS (column_name 'time'), v1  integer OPTIONS (column_name 'value1')) SERVER server1  OPTIONS (table 'cpu');
+SELECT * FROM t5;
           t          |         tag1         | v1  
 ---------------------+----------------------+-----
  2015-08-18 00:00:00 | 2015-08-18T00:00:00Z | 100
@@ -436,6 +375,7 @@ DROP FOREIGN TABLE t1;
 DROP FOREIGN TABLE t2;
 DROP FOREIGN TABLE t3;
 DROP FOREIGN TABLE t4;
+DROP FOREIGN TABLE t5;
 DROP USER MAPPING FOR CURRENT_USER SERVER server1;
 DROP SERVER server1;
 DROP EXTENSION influxdb_fdw CASCADE;

--- a/influxdb_fdw--1.0.sql
+++ b/influxdb_fdw--1.0.sql
@@ -23,3 +23,44 @@ LANGUAGE C STRICT;
 CREATE FOREIGN DATA WRAPPER influxdb_fdw
   HANDLER influxdb_fdw_handler
   VALIDATOR influxdb_fdw_validator;
+
+CREATE FUNCTION last_value_sfunc(anyelement, timestamp with time zone, anyelement)
+RETURNS anyelement
+IMMUTABLE
+
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE 'Cannot execute this function in PostgreSQL';
+END;
+$$;
+
+CREATE FUNCTION last_value_finalfunc_bigint(anyelement)
+RETURNS anyelement
+IMMUTABLE
+
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE 'Cannot execute this function in PostgreSQL';
+END;
+$$;
+
+
+CREATE AGGREGATE last (timestamp with time zone, anyelement)
+(
+    sfunc = last_value_sfunc,
+    stype = anyelement
+);
+
+CREATE FUNCTION influx_time(timestamp with time zone, interval, interval) RETURNS timestamp with time zone AS $$
+BEGIN
+RAISE 'Cannot execute this function in PostgreSQL';
+END
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE FUNCTION influx_time(timestamp with time zone, interval) RETURNS timestamp with time zone AS $$
+BEGIN
+RAISE 'Cannot execute this function in PostgreSQL';
+END
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/influxdb_fdw.c
+++ b/influxdb_fdw.c
@@ -700,12 +700,6 @@ influxdbGetForeignPlan(
 							 fdw_scan_tlist);
 
 	/*
-	 * if (baserel->reloptkind == RELOPT_JOINREL || baserel->reloptkind ==
-	 * RELOPT_UPPER_REL) fdw_private = lappend(fdw_private,
-	 * makeString(fpinfo->relation_name->data));
-	 */
-
-	/*
 	 * Create the ForeignScan node from target list, local filtering
 	 * expressions, remote parameter expressions, and FDW private information.
 	 *
@@ -971,7 +965,8 @@ influxdbIterateForeignScan(ForeignScanState *node)
 								festate->numParams);
 			if (ret.r1 != NULL)
 			{
-				char *err = pstrdup(ret.r1);
+				char	   *err = pstrdup(ret.r1);
+
 				free(ret.r1);
 				ret.r1 = err;
 				elog(ERROR, "influxdb_fdw : %s", err);
@@ -989,7 +984,7 @@ influxdbIterateForeignScan(ForeignScanState *node)
 				festate->rows[i] = palloc(sizeof(Datum) * tupleDescriptor->natts);
 				festate->rows_isnull[i] = palloc(sizeof(bool) * tupleDescriptor->natts);
 				make_tuple_from_result_row(&(result->rows[i]),
-										   (struct InfluxDBResult*)result,
+										   (struct InfluxDBResult *) result,
 										   tupleDescriptor,
 										   festate->rows[i],
 										   festate->rows_isnull[i],

--- a/influxdb_fdw.h
+++ b/influxdb_fdw.h
@@ -76,7 +76,7 @@ typedef struct InfluxDBFdwExecState
 	int64		rowidx;			/* current index of rows */
 	bool	  **rows_isnull;	/* is null */
 	bool		for_update;		/* true if this scan is update target */
-	List	   *skip_attrs;		/* skip attrs */
+	bool		is_agg;			/* scan is aggregate or not */
 	List	   *tlist;			/* target list */
 	/* working memory context */
 	MemoryContext temp_cxt;		/* context for per-tuple temporary data */
@@ -150,7 +150,7 @@ extern influxdb_opt * influxdb_get_options(Oid foreigntableid);
 extern void influxdbDeparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel,
 								List *tlist, List *remote_conds, List *pathkeys,
 								bool is_subquery, List **retrieved_attrs,
-								List **params_list, List **skip_attrs);
+								List **params_list);
 extern void influxdb_deparse_insert(StringInfo buf, PlannerInfo *root, Index rtindex, Relation rel, List *targetAttrs);
 extern void influxdb_deparse_update(StringInfo buf, PlannerInfo *root, Index rtindex, Relation rel, List *targetAttrs, List *attname);
 extern void influxdb_deparse_delete(StringInfo buf, PlannerInfo *root, Index rtindex, Relation rel, List *name);

--- a/influxdb_fdw.h
+++ b/influxdb_fdw.h
@@ -51,6 +51,7 @@ typedef struct InfluxDBFdwExecState
 {
 	char	   *query;			/* Query string */
 	Relation	rel;			/* relcache entry for the foreign table */
+	Oid			relid;			/* relation oid */
 	List	   *retrieved_attrs;	/* list of target attribute numbers */
 
 	char	  **params;
@@ -75,6 +76,8 @@ typedef struct InfluxDBFdwExecState
 	int64		rowidx;			/* current index of rows */
 	bool	  **rows_isnull;	/* is null */
 	bool		for_update;		/* true if this scan is update target */
+	List	   *skip_attrs;		/* skip attrs */
+	List	   *tlist;			/* target list */
 	/* working memory context */
 	MemoryContext temp_cxt;		/* context for per-tuple temporary data */
 	AttrNumber *junk_idx;
@@ -147,7 +150,7 @@ extern influxdb_opt * influxdb_get_options(Oid foreigntableid);
 extern void influxdbDeparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel,
 								List *tlist, List *remote_conds, List *pathkeys,
 								bool is_subquery, List **retrieved_attrs,
-								List **params_list);
+								List **params_list, List **skip_attrs);
 extern void influxdb_deparse_insert(StringInfo buf, PlannerInfo *root, Index rtindex, Relation rel, List *targetAttrs);
 extern void influxdb_deparse_update(StringInfo buf, PlannerInfo *root, Index rtindex, Relation rel, List *targetAttrs, List *attname);
 extern void influxdb_deparse_delete(StringInfo buf, PlannerInfo *root, Index rtindex, Relation rel, List *name);
@@ -156,11 +159,13 @@ extern void influxdb_append_where_clause(StringInfo buf, PlannerInfo *root, RelO
 extern void influxdb_deparse_analyze(StringInfo buf, char *dbname, char *relname);
 extern void influxdb_deparse_string_literal(StringInfo buf, const char *val);
 extern List *influxdb_build_tlist_to_deparse(RelOptInfo *foreignrel);
-int			influxdb_set_transmission_modes(void);
-void		influxdb_reset_transmission_modes(int nestlevel);
+extern int	influxdb_set_transmission_modes(void);
+extern void influxdb_reset_transmission_modes(int nestlevel);
 
-Datum		influxdb_convert_to_pg(Oid pgtyp, int pgtypmod, char **row, int attnum);
+extern Datum influxdb_convert_to_pg(Oid pgtyp, int pgtypmod, char **row, int attnum);
 
-void influxdb_bind_sql_var(Oid type, int attnum, Datum value, bool *isnull,
+extern void influxdb_bind_sql_var(Oid type, int attnum, Datum value, bool *isnull,
 					  InfluxDBType * param_influxdb_types, InfluxDBValue * param_influxdb_values);
+extern char *influxdb_get_function_name(Oid funcid);
+
 #endif							/* InfluxDB_FDW_H */

--- a/init.txt
+++ b/init.txt
@@ -14,3 +14,10 @@ t3,tag1=a value1=2.0,value2=100 1
 t3,tag1=a value1=3.0,value2=100 2 
 t3,tag1=b value1=10.0,value2=200 3
 t3,tag1=b value1=20.0,value2=200 4
+
+t4,tag1=a,tag2=x value1=1.0,value2=100 0 
+t4,tag1=a,tag2=y value1=2.0,value2=100 1 
+t4,tag1=a,tag2=x value1=3.0,value2=100 2 
+t4,tag1=b,tag2=y value1=10.0,value2=200 3
+t4,tag1=b,tag2=z value1=20.0,value2=200 4
+t4,tag1=b,tag2=z value1=30.0,value2=200 5

--- a/sql/aggregate.sql
+++ b/sql/aggregate.sql
@@ -15,18 +15,7 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER server1 OPTIONS(user 'user', passwor
 IMPORT FOREIGN SCHEMA public FROM SERVER server1 INTO public OPTIONS(import_time_text 'true');
 
 
-CREATE FUNCTION influx_time(timestamp with time zone, interval, interval) RETURNS timestamp with time zone AS $$
-BEGIN
-RAISE 'Cannot execute this function in PostgreSQL';
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
 
-
-CREATE FUNCTION influx_time(timestamp with time zone, interval) RETURNS timestamp with time zone AS $$
-BEGIN
-RAISE 'Cannot execute this function in PostgreSQL';
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
 
 --ALTER EXTENSION influxdb_fdw ADD FUNCTION postgres_fdw_abs(int);
 --ALTER SERVER server1 OPTIONS (ADD extensions 'influxdb_fdw');
@@ -52,36 +41,7 @@ SELECT tag1,sum("value1"), count(value1), tag2 FROM "t4" group by tag1, tag2;
 EXPLAIN (verbose)  SELECT tag1,sum("value1"), count(value1), tag2 FROM "t4" group by tag1, tag2;
 
 
-CREATE FUNCTION last_value_sfunc(anyelement, timestamp with time zone, anyelement)
-RETURNS anyelement
-IMMUTABLE
 
-LANGUAGE PLPGSQL
-AS $$
-BEGIN
-  RAISE 'Cannot execute this function in PostgreSQL';
-END;
-$$;
-
-CREATE FUNCTION last_value_finalfunc_bigint(anyelement)
-RETURNS anyelement
-IMMUTABLE
-
-LANGUAGE PLPGSQL
-AS $$
-BEGIN
-  RAISE 'Cannot execute this function in PostgreSQL';
-END;
-$$;
-
-
-CREATE AGGREGATE last (timestamp with time zone, anyelement)
-(
-    sfunc = last_value_sfunc,
-    --basetype = anyelement,
-    stype = anyelement
-    --finalfunc = last_value_finalfunc_text
-);
 
 SELECT influx_time(time,interval '5s',interval '0s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
  GROUP BY influx_time(time,interval '5s', interval '0s'), tag1;

--- a/sql/aggregate.sql
+++ b/sql/aggregate.sql
@@ -1,0 +1,115 @@
+
+--SET log_min_messages=debug1;
+--SET client_min_messages=debug1;
+SET datestyle=ISO;
+-- timestamp with time zone differs based on this
+SET timezone='UTC';
+
+CREATE EXTENSION influxdb_fdw;
+CREATE SERVER server1 FOREIGN DATA WRAPPER influxdb_fdw OPTIONS
+(dbname 'mydb', host 'http://localhost', port '8086') ;
+CREATE USER MAPPING FOR CURRENT_USER SERVER server1 OPTIONS(user 'user', password 'pass');
+
+
+-- import time column as timestamp and text type
+IMPORT FOREIGN SCHEMA public FROM SERVER server1 INTO public OPTIONS(import_time_text 'true');
+
+
+CREATE FUNCTION influx_time(timestamp with time zone, interval, interval) RETURNS timestamp with time zone AS $$
+BEGIN
+RAISE 'Cannot execute this function in PostgreSQL';
+END
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+
+CREATE FUNCTION influx_time(timestamp with time zone, interval) RETURNS timestamp with time zone AS $$
+BEGIN
+RAISE 'Cannot execute this function in PostgreSQL';
+END
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+--ALTER EXTENSION influxdb_fdw ADD FUNCTION postgres_fdw_abs(int);
+--ALTER SERVER server1 OPTIONS (ADD extensions 'influxdb_fdw');
+
+SELECT * FROM t4;
+
+EXPLAIN (verbose)  
+SELECT sum("value1"),influx_time(time,interval '1s', interval '0.00001s'),tag1 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '1s', interval '0.00001s'), tag1;
+SELECT sum("value1"),influx_time(time,interval '1s', interval '0.00001s'),tag1 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '1s', interval '0.00001s'), tag1;
+
+
+EXPLAIN (verbose) 
+SELECT tag1,sum("value1"),tag2 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+ GROUP BY tag2, tag1;
+SELECT tag1,sum("value1"),tag2 FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+ GROUP BY tag2, tag1;
+
+
+
+SELECT tag1,sum("value1"), count(value1), tag2 FROM "t4" group by tag1, tag2;
+EXPLAIN (verbose)  SELECT tag1,sum("value1"), count(value1), tag2 FROM "t4" group by tag1, tag2;
+
+
+CREATE FUNCTION last_value_sfunc(anyelement, timestamp with time zone, anyelement)
+RETURNS anyelement
+IMMUTABLE
+
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE 'Cannot execute this function in PostgreSQL';
+END;
+$$;
+
+CREATE FUNCTION last_value_finalfunc_bigint(anyelement)
+RETURNS anyelement
+IMMUTABLE
+
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE 'Cannot execute this function in PostgreSQL';
+END;
+$$;
+
+
+CREATE AGGREGATE last (timestamp with time zone, anyelement)
+(
+    sfunc = last_value_sfunc,
+    --basetype = anyelement,
+    stype = anyelement
+    --finalfunc = last_value_finalfunc_text
+);
+
+SELECT influx_time(time,interval '5s',interval '0s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+ GROUP BY influx_time(time,interval '5s', interval '0s'), tag1;
+
+EXPLAIN (VERBOSE)
+SELECT influx_time(time,interval '5s',interval '0s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '5s', interval '0s'), tag1;
+
+-- no offset 
+SELECT influx_time(time,interval '5s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
+GROUP BY influx_time(time,interval '5s'), tag1;
+
+EXPLAIN (verbose) 
+SELECT last(time, value1),last(time, value2) FROM t4 GROUP BY tag1;
+SELECT last(time, value1),last(time, value2) FROM t4 GROUP BY tag1;
+
+-- InfluxDB does not return error for the following query
+--SELECT sum(value1) FROM t4 GROUP BY value1;
+
+-- not allowed
+SELECT sum(value1) FROM t4 GROUP BY time;
+
+--last returns NULL for tag
+--SELECT last(time, value1),last(time, value2),last(time, tag1) FROM t4 GROUP BY tag1;
+
+DROP FOREIGN TABLE t3;
+DROP FOREIGN TABLE t4;
+DROP FOREIGN TABLE cpu;
+DROP USER MAPPING FOR CURRENT_USER SERVER server1;
+DROP SERVER server1;
+DROP EXTENSION influxdb_fdw ;

--- a/sql/influxdb_fdw.sql
+++ b/sql/influxdb_fdw.sql
@@ -17,9 +17,10 @@ SELECT value1,time,value2 FROM cpu;
 SELECT value1,time_text,value2 FROM cpu;
 DROP FOREIGN TABLE cpu;
 DROP FOREIGN TABLE t3;
+DROP FOREIGN TABLE t4;
 
 -- test EXECPT
-IMPORT FOREIGN SCHEMA public EXCEPT (cpu,t3) FROM SERVER server1 INTO public;
+IMPORT FOREIGN SCHEMA public EXCEPT (cpu,t3, t4) FROM SERVER server1 INTO public;
 SELECT ftoptions FROM pg_foreign_table;
 
 -- test LIMIT TO
@@ -97,23 +98,6 @@ SELECT * FROM t2 WHERE time + interval '1 week 1 day 5 hour 43 minute 21 second 
 SELECT * FROM t2 WHERE time = TIMESTAMP '2015-09-18 00:00:00' - interval '1 months';
 EXPLAIN (verbose)  SELECT * FROM t2 WHERE time = TIMESTAMP '2015-09-18 00:00:00' - interval '1 months';
 
-
-SELECT * FROM t3;
-
-EXPLAIN (verbose, costs off) SELECT
-sum(value1), max(value1),count(*) FROM t3;
-SELECT sum(value1), max(value1),count(*) FROM t3;
-
-EXPLAIN (verbose, costs off) 
-SELECT avg(value1) FROM t3;
-SELECT avg(value1) FROM t3;
-
-
--- Not pushdown aggregates with GROUP BY because "SELECT sum(value1),tag1" cause error "mixing aggregate and non-aggregate queries is not supported"
-EXPLAIN (verbose, costs off) 
-SELECT sum(value1) FROM t3 GROUP BY "tag1";
-SELECT sum(value1) FROM t3 GROUP BY "tag1";
-
 -- Currently using column_name 'time' does not work 
 -- CREATE FOREIGN TABLE t(tm timestamp OPTIONS (column_name 'time'),tm_with_zone timestamp with time zone OPTIONS (column_name 'time'), tag1 text,value1 integer) SERVER server1  OPTIONS (table 'cpu');
 SELECT * FROM t2 WHERE value1 = ANY (ARRAY(SELECT value1 FROM t1 WHERE value1 < 1000));
@@ -123,13 +107,14 @@ SELECT * FROM t1;
 ALTER SERVER server1 OPTIONS (SET dbname 'mydb');
 SELECT * FROM t1;
 
-CREATE FOREIGN TABLE t4(t timestamp OPTIONS (column_name 'time') , tag1 text OPTIONS (column_name 'time'), v1  integer OPTIONS (column_name 'value1')) SERVER server1  OPTIONS (table 'cpu');
-SELECT * FROM t4;
+CREATE FOREIGN TABLE t5(t timestamp OPTIONS (column_name 'time') , tag1 text OPTIONS (column_name 'time'), v1  integer OPTIONS (column_name 'value1')) SERVER server1  OPTIONS (table 'cpu');
+SELECT * FROM t5;
 
 DROP FOREIGN TABLE t1;
 DROP FOREIGN TABLE t2;
 DROP FOREIGN TABLE t3;
 DROP FOREIGN TABLE t4;
+DROP FOREIGN TABLE t5;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER server1;
 DROP SERVER server1;


### PR DESCRIPTION
This pull request includes:
* GROUP BY push down
* Add `last()` aggregate function and `influx_time()` functions

These functions can be used for using InfluxDB `last()` function and `GROUP BY time(duration)`.
But these functions do not have implementation in PostgreSQL and can be used if these are pushed down.

Usage example:
```
EXPLAIN (VERBOSE)
SELECT influx_time(time,interval '5s',interval '0s'),tag1,last(time, value1) FROM "t4" WHERE time >= '1970-01-01 00:00:00+00' and time <= '1970-01-01 0:00:05+00' 
GROUP BY influx_time(time,interval '5s', interval '0s'), tag1;
                                                                                   QUERY PLAN                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Foreign Scan  (cost=1.00..1.00 rows=1 width=48)
   Output: (influx_time("time", '@ 5 secs'::interval, '@ 0'::interval)), tag1, (last("time", value1))
   InfluxDB query: SELECT last("value1") FROM "t4" WHERE ((time >= '1970-01-01 00:00:00')) AND ((time <= '1970-01-01 00:00:05')) GROUP BY (time(0d0h0m5s0u, 0d0h0m0s0u)), "tag1"
```