### PR TITLE
fix build on macOS and PostgreSQL 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ UNAME = uname
 OS := $(shell $(UNAME))
 ifeq ($(OS), Darwin)
 DLSUFFIX = .dylib
+PG_LDFLAGS = -framework CoreFoundation -framework Security
 else
 DLSUFFIX = .so
 endif
@@ -32,8 +33,8 @@ include $(PGXS)
 ifndef MAJORVERSION
 MAJORVERSION := $(basename $(VERSION))
 endif
-ifeq (,$(findstring $(MAJORVERSION), 9.6 10 11))
-$(error PostgreSQL 9.6, 10 or 11 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.6 10 11 12))
+$(error PostgreSQL 9.6, 10, 11 or 12 is required to compile this extension)
 endif
 
 else


### PR DESCRIPTION
Allow version 12 in test.

Add frameworks to linker flags to fix: Undefined symbols for architecture x86_64: "_CFArrayGetCount"

The first fix is easy and solves `Makefile:36: *** PostgreSQL 9.6, 10 or 11 is required to compile this extension.`

The second fix is necessary because the go cgo (tested both 1.14 and 1.15) links a certain library, but the Postgres extension does not. This caused missing symbols:

```
Undefined symbols for architecture x86_64:
  "_CFArrayGetCount", referenced from:
      _crypto/x509/internal/macos.x509_CFArrayGetCount_trampoline in query.a(go.o)
      __cgo_72cdce5fb1c1_Cfunc_CopyPEMRoots in query.a(000017.o)
  "_CFArrayGetValueAtIndex", referenced from:
(...)
```
